### PR TITLE
Hover nav

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -196,9 +196,10 @@ h4, .h4, h5, .h5, h6, .h6 {
     box-shadow: none;
     padding: 0;
 }
-
-.dropdown:hover .dropdown-menu {
-    display: block;
+@media (min-width: 992px) {
+    .dropdown:hover .dropdown-menu {
+        display: block;
+    }
 }
 
 .dropdown-menu li a {


### PR DESCRIPTION
Fixed bug for smartphones in which clicking navbar element was recognized as a hovering action and displayed the navigation submenus improperly.